### PR TITLE
Updates from napari plugin dev

### DIFF
--- a/microfilm/microplot.py
+++ b/microfilm/microplot.py
@@ -604,7 +604,7 @@ class Microimage:
             # The factor (1-tot_space) is a rescaling of the y position to take into
             # account that the axis only occupies that portion of the figure
             if channel_colors is not None:
-                text_color = channel_colors[i]
+                text_color = channel_colors[nlines-1-i]
             elif self.flip_map[nlines-1-i] is False:
                 text_color = self.cmap_objects[nlines-1-i](self.cmap_objects[nlines-1-i].N)
             else:
@@ -748,7 +748,7 @@ class Micropanel:
                         
                         # find text color
                         if channel_colors is not None:
-                            text_color = channel_colors[j][i][k]
+                            text_color = channel_colors[j][i][num_lines-1-k]
                         elif self.microplots[j,i].flip_map[num_lines-1-k] is False:
                             text_color = self.microplots[j,i].cmap_objects[num_lines-1-k](self.microplots[j,i].cmap_objects[num_lines-1-k].N)
                         else:

--- a/microfilm/microplot.py
+++ b/microfilm/microplot.py
@@ -15,8 +15,8 @@ def microshow(
     images=None, cmaps=None, flip_map=False, rescale_type=None, limits=None, 
     num_colors=256, proj_type='max', alpha=0.5, volume_proj=None, channel_names=None,
     channel_label_show=False, channel_label_type='title', channel_label_size=0.1,
-    scalebar_thickness=0.02, scalebar_unit_per_pix=None, scalebar_size_in_units=None,
-    unit=None, scalebar_location='lower right', scalebar_color='white',
+    channel_label_line_space=0.1, scalebar_thickness=0.02, scalebar_unit_per_pix=None,
+    scalebar_size_in_units=None, unit=None, scalebar_location='lower right', scalebar_color='white',
     scalebar_font_size=12, scalebar_kwargs=None, scalebar_font_properties=None,
     ax=None, fig_scaling=3, dpi=72, label_text=None, label_location='upper left',
     label_color='white', label_font_size=15, label_kwargs={}, cmap_objects=None,
@@ -65,6 +65,8 @@ def microshow(
         'title', 'in_fig'
     channel_label_size: float
         relative font size for channel labels
+    channel_label_line_space: float
+        space between channel labels as fraction of channel_label_size
     scalebar_thickness: float
         fraction height of scale bar
     scalebar_unit_per_pix: float
@@ -125,9 +127,9 @@ def microshow(
             limits=limits, num_colors=num_colors, proj_type=proj_type, alpha=alpha,
             volume_proj=volume_proj, channel_names=channel_names, channel_label_show=channel_label_show,
             channel_label_type=channel_label_type, channel_label_size=channel_label_size,
-            scalebar_thickness=scalebar_thickness, scalebar_unit_per_pix=scalebar_unit_per_pix,
-            scalebar_size_in_units=scalebar_size_in_units, unit=unit,
-            scalebar_location=scalebar_location, scalebar_color=scalebar_color,
+            channel_label_line_space=channel_label_line_space, scalebar_thickness=scalebar_thickness,
+            scalebar_unit_per_pix=scalebar_unit_per_pix, scalebar_size_in_units=scalebar_size_in_units,
+            unit=unit, scalebar_location=scalebar_location, scalebar_color=scalebar_color,
             scalebar_font_size=scalebar_font_size, scalebar_kwargs=scalebar_kwargs,
             scalebar_font_properties=scalebar_font_properties, ax=ax, fig_scaling=fig_scaling,
             dpi=dpi, label_text=label_text, label_location=label_location,
@@ -262,6 +264,8 @@ class Microimage:
         'title', 'in_fig'
     channel_label_size: float
         relative font size of channel label
+    channel_label_line_space: float
+        space between channel labels as fraction of channel_label_size
     scalebar_thickness: float
         fraction of height of scale bar
     scalebar_unit_per_pix: float
@@ -311,8 +315,8 @@ class Microimage:
         self, images, cmaps=None, flip_map=False, rescale_type=None, limits=None,
         num_colors=256, proj_type='max', alpha=0.5, volume_proj=None, channel_names=None,
         channel_label_show=False, channel_label_type='title', channel_label_size=0.1,
-        scalebar_thickness=0.02, scalebar_unit_per_pix=None, scalebar_size_in_units=None,
-        unit=None, scalebar_location='lower right', scalebar_color='white',
+        channel_label_line_space=0.1, scalebar_thickness=0.02, scalebar_unit_per_pix=None,
+        scalebar_size_in_units=None, unit=None, scalebar_location='lower right', scalebar_color='white',
         scalebar_font_size=12, scalebar_kwargs=None, scalebar_font_properties=None,
         ax=None, fig_scaling=3, dpi=72, label_text=None, label_location='upper left',
         label_color='white', label_font_size=15, label_kwargs={}, cmap_objects=None,
@@ -556,7 +560,7 @@ class Microimage:
 
     def add_channel_labels(
         self, channel_names=None, channel_label_size=None,
-        label_line_space=0.1, channel_colors=None):
+        channel_label_line_space=None, channel_colors=None):
         """
         Add the channel names color with the corresponding colormap as figure title
 
@@ -566,7 +570,7 @@ class Microimage:
             list of channel names, defaults to channel-1, channel-2 etc.
         channel_label_size: float
             relative font size of label
-        label_line_space: float
+        channel_label_line_space: float
             size of space between labels as fraction of channel_label_size
         channel_colors: list of array
             list of colors to use for the label each channel,
@@ -576,7 +580,8 @@ class Microimage:
 
         if channel_label_size is not None:
             self.channel_label_size = channel_label_size
-        self.label_line_space = label_line_space
+        if channel_label_line_space is not None:
+            self.channel_label_line_space = channel_label_line_space
 
         if channel_names is not None:
             self.channel_names = channel_names
@@ -586,7 +591,7 @@ class Microimage:
         px = 1/plt.rcParams['figure.dpi']
         figheight_px = self.fig.get_size_inches()[1] / px
         
-        line_space = self.label_line_space * self.channel_label_size
+        line_space = self.channel_label_line_space * self.channel_label_size
         nlines = len(self.channel_names)
         tot_space =  ((nlines+0.5) * self.channel_label_size + (nlines-1)*line_space)
 
@@ -643,6 +648,8 @@ class Micropanel:
         figure size [x, y]
     channel_label_size: float
         font size for channel labels (fraction of figure)
+    channel_label_line_space: float
+        space between channel labels (fraction of channel_label_size)
     fig_kwargs: parameters normally passed to plt.subplots()
 
     Attributes
@@ -657,7 +664,7 @@ class Micropanel:
     
     def __init__(
         self, rows, cols, margin=0.01, figscaling=5, figsize=None,
-        channel_label_size=0.05, label_line_space=0.1, **fig_kwargs):
+        channel_label_size=0.05, channel_label_line_space=0.1, **fig_kwargs):
 
         self.rows = rows
         self.cols = cols
@@ -665,7 +672,7 @@ class Micropanel:
         self.figsize = figsize
         self.figscaling = figscaling
         self.channel_label_size = channel_label_size
-        self.label_line_space = label_line_space
+        self.channel_label_line_space = channel_label_line_space
         self.fig_kwargs = fig_kwargs
 
         self.microplots = np.empty((rows, cols), dtype=object)
@@ -683,14 +690,14 @@ class Micropanel:
             gridspec_kw = {'left':0, 'right':1, 'bottom':0, 'top':1, 'wspace':self.margin, 'hspace':self.margin},
             **self.fig_kwargs)
 
-    def add_channel_label(self, channel_label_size=None, label_line_space=None,
+    def add_channel_label(self, channel_label_size=None, channel_label_line_space=None,
                           channel_names=None, channel_colors=None):
         """Add channel labels to all plots and set their size"""
 
         if channel_label_size is not None:
             self.channel_label_size = channel_label_size
-        if label_line_space is not None:
-            self.label_line_space = label_line_space
+        if channel_label_line_space is not None:
+            self.channel_label_line_space = channel_label_line_space
 
         for i in range(self.rows):
             for j in range(self.cols):
@@ -704,7 +711,7 @@ class Micropanel:
         px = 1/plt.rcParams['figure.dpi']
         figheight_px = self.fig.get_size_inches()[1] / px
 
-        line_space = self.label_line_space * self.channel_label_size
+        line_space = self.channel_label_line_space * self.channel_label_size
         nlines = np.max([len(k) for k in [x.channel_names for x in self.microplots.ravel() if x is not None] if k is not None])
 
         tot_space =  ((nlines+0.5) * self.channel_label_size + (nlines-1)*line_space)

--- a/microfilm/microplot.py
+++ b/microfilm/microplot.py
@@ -669,7 +669,7 @@ class Micropanel:
             gridspec_kw = {'left':0, 'right':1, 'bottom':0, 'top':1, 'wspace':self.margin, 'hspace':self.margin},
             **self.fig_kwargs)
 
-    def add_channel_label(self, channel_label_size=None, label_line_space=None,
+    def add_channel_label(self, channel_label_size=0.05, label_line_space=0.1,
                           channel_names=None, channel_colors=None):
         """Add channel labels to all plots and set their size"""
 
@@ -680,17 +680,22 @@ class Micropanel:
 
         for i in range(self.rows):
             for j in range(self.cols):
-                if channel_names is not None:
-                    self.microplots[i,j].channel_names = channel_names[i][j]
-                elif self.microplots[i,j].channel_names is None:
-                    self.microplots[i,j].channel_names = ['Channel-' + str(i) for i in range(len(self.microplots[i,j].images))]
+                if self.microplots[i,j] is not None:
+                    if channel_names is not None:
+                        self.microplots[i,j].channel_names = channel_names[i][j]
+                    elif self.microplots[i,j].channel_names is None:
+                        self.microplots[i,j].channel_names = ['Channel-' + str(i) for i in range(len(self.microplots[i,j].images))]
         
         ## title params
+        px = 1/plt.rcParams['figure.dpi']
+        figheight_px = self.fig.get_size_inches()[1] / px
+
         line_space = self.label_line_space * self.channel_label_size
         nlines = np.max([len(k) for k in [x.channel_names for x in self.microplots.ravel() if x is not None] if k is not None])
 
-        tot_space = nlines * (self.channel_label_size+line_space)
-        fontsize = self.channel_label_size*self.fig.get_size_inches()[1]*self.rows*100
+        tot_space =  (nlines * self.channel_label_size + (nlines-0.5)*line_space)
+        # make the font size the fraction of the figure height *remaining* after adding the text
+        fontsize = int(figheight_px * (1-(self.rows * tot_space)) * self.channel_label_size)
 
         # adjust figure size with label
         self.fig.clf()
@@ -733,7 +738,7 @@ class Micropanel:
                             text_to_plot = self.microplots[j, i].channel_names[num_lines-1-k]
                         self.fig.text(
                             x=xpos,
-                            y = ypos + line_space+k*(self.channel_label_size+line_space),
+                            y = ypos + 0.5 * self.channel_label_size + k * (self.channel_label_size+line_space),
                             s=text_to_plot, ha="center",
                             transform=self.fig.transFigure,
                             fontdict={'color': text_color, 'size':fontsize}

--- a/microfilm/microplot.py
+++ b/microfilm/microplot.py
@@ -669,7 +669,8 @@ class Micropanel:
             gridspec_kw = {'left':0, 'right':1, 'bottom':0, 'top':1, 'wspace':self.margin, 'hspace':self.margin},
             **self.fig_kwargs)
 
-    def add_channel_label(self, channel_label_size=None, label_line_space=None):
+    def add_channel_label(self, channel_label_size=None, label_line_space=None,
+                          channel_names=None, channel_colors=None):
         """Add channel labels to all plots and set their size"""
 
         if channel_label_size is not None:
@@ -679,7 +680,9 @@ class Micropanel:
 
         for i in range(self.rows):
             for j in range(self.cols):
-                if self.microplots[i,j].channel_names is None:
+                if channel_names is not None:
+                    self.microplots[i,j].channel_names = channel_names[i][j]
+                elif self.microplots[i,j].channel_names is None:
                     self.microplots[i,j].channel_names = ['Channel-' + str(i) for i in range(len(self.microplots[i,j].images))]
         
         ## title params
@@ -713,21 +716,24 @@ class Micropanel:
 
                     xpos = self.ax[j,i].get_position().bounds[0]+0.5*self.ax[j,i].get_position().bounds[2]
                     ypos = self.ax[j,i].get_position().bounds[1]+self.ax[j,i].get_position().bounds[3]
+                    num_lines = len(self.microplots[j,i].channel_names)
 
-                    for k in range(nlines):
+                    for k in range(num_lines):
                         
                         # find text color
-                        if self.microplots[j,i].flip_map[nlines-1-k] is False:
-                            text_color = self.microplots[j,i].cmap_objects[nlines-1-k](self.microplots[j,i].cmap_objects[nlines-1-k].N)
+                        if channel_colors is not None:
+                            text_color = channel_colors[j][i][k]
+                        elif self.microplots[j,i].flip_map[num_lines-1-k] is False:
+                            text_color = self.microplots[j,i].cmap_objects[num_lines-1-k](self.microplots[j,i].cmap_objects[num_lines-1-k].N)
                         else:
-                            text_color = self.microplots[j,i].cmap_objects[nlines-1-k](0)
+                            text_color = self.microplots[j,i].cmap_objects[num_lines-1-k](0)
 
                         text_to_plot = " "
                         if self.microplots[j, i].channel_names is not None:
-                            text_to_plot = self.microplots[j, i].channel_names[nlines-1-k]
+                            text_to_plot = self.microplots[j, i].channel_names[num_lines-1-k]
                         self.fig.text(
                             x=xpos,
-                            y = ypos + line_space + +k*(self.channel_label_size+line_space),
+                            y = ypos + line_space+k*(self.channel_label_size+line_space),
                             s=text_to_plot, ha="center",
                             transform=self.fig.transFigure,
                             fontdict={'color': text_color, 'size':fontsize}


### PR DESCRIPTION
While developing a napari companion plugin for microfilm, several issues appeared especially around scaling and position of channel labels. This PR brings the following improvements:
- the size of the channel labels via ```channel_label_size``` better respects its definition as fraction of the figure size, especially for multi-row panels.
- channel labels should no more be superposed on the top of the image
- the space between the chanel labels can be set now with ```channel_labels_line_space```
- when adding channel labels, one can override the defaults using the ```channel_names``` and ```channel_colors```options. This is used in napari when taking screen captures of multi-channel images that directly end-up as RGB images. When displaying them, the color channels should not be RGB but whatever colormap was used in napari, which can now be passed as an argument