### PR TITLE
make aicsimageio, nd2, ffmpeg, ipywidget optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,32 @@ To test the package via the Jupyter interface and the notebooks available [here]
 conda env create -f environment.yml
 ```
 
+### Optional installs
+
+If you want to use the ```dataset``` submodule (see below in Additional functionalities) and need to handle multipage tiff files or nd2 files, use:
+
+```
+pip install "microfilm[multipage]"
+```
+
+or 
+
+```
+pip install "microfilm[nd2]"
+```
+
+If you plan to not just use simple plotting but want to create animations, you need to install:
+
+```
+pip install "microfilm[animation]"
+```
+
+To install all options use:
+
+```
+pip install "microfilm[all]"
+```
+
 ## Simple plot
 
 It is straightforward to create a ready-to-use plot of a multi-channel image dataset. In the following code snippet, we load a Numpy array of a multi-channel time-lapse dataset with shape ```CTXY``` (three channels). The figure below showing the time-point ```t=10``` is generated in a single command with a few options and saved as a png:

--- a/microfilm/dataset/dataset.py
+++ b/microfilm/dataset/dataset.py
@@ -3,8 +3,6 @@ import re
 from pathlib import Path
 import warnings
 
-from aicsimageio import AICSImage, readers
-from nd2reader import ND2Reader
 import h5py
 import skimage.io
 import numpy as np
@@ -231,6 +229,8 @@ class MultipageTIFF(Data):
 
     def initialize(self):
         
+        from aicsimageio import AICSImage, readers
+
         # if no channel names are provided, consider all folders as channel
         if self.channel_name is None:
             self.channel_name = self.find_files(self.expdir, check_time=False)
@@ -292,6 +292,8 @@ class ND2(Data):
 
     def initialize(self):
         
+        from nd2reader import ND2Reader
+
         self.nd2file = ND2Reader(self.expdir.as_posix())
         self.nd2file.metadata["z_levels"] = range(0)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ multipage =
     aicsimageio
 nd2 =
     nd2reader
-movie =
+animation =
     imageio-ffmpeg
     ipywidgets
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,12 +36,23 @@ install_requires =
     scikit-image
     matplotlib
     matplotlib-scalebar
-    aicsimageio
     tifffile
-    nd2reader
     h5py
     xarray
     natsort
-    ipywidgets
     imageio
+
+[options.extras_require]
+multipage =
+    aicsimageio
+nd2 =
+    nd2reader
+movie =
     imageio-ffmpeg
+    ipywidgets
+all =
+    aicsimageio
+    nd2reader
+    imageio-ffmpeg
+    ipywidgets
+

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,7 @@ platform =
 deps = 
     pytest
 
+extras =
+    all
+
 commands = pytest -v


### PR DESCRIPTION
Both aicsimageio and nd2 are only needed to handle multipage tiff and nd2 files. For the majority of cases, where users only want to display Numpy arrays these are not needed and because of complex dependencies make the installation complicated. They are now moved as optional installs.

Similarly, imageio-ffmpeg and ipywidgets which are only used for animations are also available optionally to make the installation lighter.